### PR TITLE
Add custom gRPC interceptor

### DIFF
--- a/discovery/interceptor.go
+++ b/discovery/interceptor.go
@@ -1,0 +1,99 @@
+package discovery
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const tokenField = "x-consul-token"
+
+func makeUnaryInterceptor(watcher *Watcher) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply interface{},
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		ctx = interceptContext(watcher, ctx)
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		interceptError(watcher, err)
+		return err
+	}
+}
+
+func makeStreamInterceptor(watcher *Watcher) grpc.StreamClientInterceptor {
+	return func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		ctx = interceptContext(watcher, ctx)
+		stream, err := streamer(ctx, desc, cc, method, opts...)
+		interceptError(watcher, err)
+		if err != nil {
+			return nil, err
+		}
+		return &streamWrapper{ClientStream: stream, watcher: watcher}, nil
+	}
+}
+
+type streamWrapper struct {
+	grpc.ClientStream
+	watcher *Watcher
+}
+
+func (s *streamWrapper) SendMsg(m interface{}) error {
+	err := s.ClientStream.SendMsg(m)
+	interceptError(s.watcher, err)
+	return err
+}
+
+func (s *streamWrapper) RecvMsg(m interface{}) error {
+	err := s.ClientStream.RecvMsg(m)
+	interceptError(s.watcher, err)
+	return err
+}
+
+// interceptContext will automatically include the ACL token on the context.
+func interceptContext(watcher *Watcher, ctx context.Context) context.Context {
+	token, ok := watcher.token.Load().(string)
+	if !ok || token == "" {
+		// no token to add to context
+		return ctx
+	}
+
+	// skip if there is already a token in the context
+	if md, ok := metadata.FromOutgoingContext(ctx); ok {
+		if tok := md.Get(tokenField); len(tok) > 0 {
+			return ctx
+		}
+	}
+
+	return metadata.AppendToOutgoingContext(ctx, tokenField, token)
+}
+
+// interceptError can automatically react to errors.
+func interceptError(watcher *Watcher, err error) {
+	if err == nil {
+		return
+	}
+
+	s, ok := status.FromError(err)
+	if !ok {
+		return
+	}
+
+	if s.Code() == codes.ResourceExhausted {
+		// TODO: tell the watcher to switch servers when we see this error code.
+		watcher.log.Debug("saw gRPC ResourceExhausted status code")
+	}
+}

--- a/discovery/interceptor_test.go
+++ b/discovery/interceptor_test.go
@@ -1,0 +1,51 @@
+package discovery
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestInterceptContext(t *testing.T) {
+	makeMD := func() metadata.MD {
+		return metadata.MD{tokenField: []string{"test-token"}}
+	}
+
+	cases := map[string]struct {
+		// configure the watcher with this token
+		watcherToken string
+		// call interceptContext with this context
+		context context.Context
+		// expect a context back with this metadata
+		expMD metadata.MD
+	}{
+		"no watcher token": {
+			context: metadata.NewOutgoingContext(context.Background(), metadata.MD{}),
+			expMD:   metadata.MD{},
+		},
+		"watcher has token": {
+			watcherToken: "test-token",
+			context:      metadata.NewOutgoingContext(context.Background(), metadata.MD{}),
+			expMD:        makeMD(),
+		},
+		"context already has token": {
+			watcherToken: "other-token",
+			context:      metadata.NewOutgoingContext(context.Background(), makeMD()),
+			expMD:        makeMD(),
+		},
+	}
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			watcher := &Watcher{}
+			watcher.token.Store(c.watcherToken)
+
+			ctx := interceptContext(watcher, c.context)
+			md, ok := metadata.FromOutgoingContext(ctx)
+			require.True(t, ok)
+			require.Equal(t, c.expMD, md)
+		})
+	}
+}

--- a/discovery/watcher_test.go
+++ b/discovery/watcher_test.go
@@ -6,50 +6,97 @@ import (
 	"testing"
 
 	"github.com/hashicorp/consul-server-connection-manager/internal/consul-proto/pbdataplane"
+	"github.com/hashicorp/consul-server-connection-manager/internal/consul-proto/pbserverdiscovery"
 	"github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
 )
 
-// TestRun starts a Consul server cluster.
+const testServerManagementToken = "12345678-90ab-cdef-0000-123456789abcd"
+
+// TestRun starts a Consul server cluster and starts a Watcher.
 func TestRun(t *testing.T) {
-	_, serverAddrs := consulServers(t, 3)
+	cases := map[string]struct {
+		config         Config
+		serverConfigFn testutil.ServerConfigCallback
+	}{
+		"no acls": {
+			config: Config{},
+		},
+		"static token": {
+			config: Config{
+				Credentials: Credentials{
+					Type: CredentialsTypeStatic,
+					Static: StaticTokenCredential{
+						Token: testServerManagementToken,
+					},
+				},
+			},
+			serverConfigFn: enableACLsConfigFn,
+		},
+	}
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 
-	ctx := context.Background()
-	w, err := NewWatcher(
-		ctx,
-		Config{},
-		hclog.New(&hclog.LoggerOptions{
-			Name:  "watcher",
-			Level: hclog.Debug,
-		}),
-	)
-	require.NoError(t, err)
+			_, serverAddrs := consulServers(t, 3, c.serverConfigFn)
 
-	// In order to test with local Consul tests servers, we set custom server ports,
-	// which we inject through custom interfaces. The Config and go-netaddrs and the
-	// server watch stream do not support per-server ports.
-	w.discoverer = &testDiscoverer{
-		addrs: serverAddrs,
+			ctx := context.Background()
+			w, err := NewWatcher(ctx, c.config, hclog.New(&hclog.LoggerOptions{
+				Name:  fmt.Sprintf("watcher/%s", name),
+				Level: hclog.Debug,
+			}),
+			)
+			require.NoError(t, err)
+
+			// In order to test with local Consul tests servers, we set custom server ports,
+			// which we inject through custom interfaces. The Config and go-netaddrs and the
+			// server watch stream do not support per-server ports.
+			w.discoverer = &testDiscoverer{addrs: serverAddrs}
+
+			// Start the Watcher.
+			go w.Run()
+			t.Cleanup(w.Stop)
+
+			// Get initial state. This blocks until initialization is complete.
+			state, err := w.State()
+			require.NoError(t, err)
+			require.NotNil(t, state)
+			require.NotNil(t, state, state.GRPCConn)
+
+			// check the token we get back.
+			switch c.config.Credentials.Type {
+			case CredentialsTypeStatic:
+				require.Equal(t, state.Token, testServerManagementToken)
+			case CredentialsTypeLogin:
+				require.FailNow(t, "TODO: support acl token login")
+			default:
+				require.Equal(t, state.Token, "")
+			}
+
+			// Make a gRPC request to check that the gRPC connection is working.
+			// This validates that the custom interceptor is injecting the ACL token.
+			{
+				unaryClient := pbdataplane.NewDataplaneServiceClient(state.GRPCConn)
+				resp, err := unaryClient.GetSupportedDataplaneFeatures(ctx, &pbdataplane.GetSupportedDataplaneFeaturesRequest{})
+				require.NoError(t, err, "error from unary request")
+				require.NotNil(t, resp)
+			}
+
+			// Check the custom interceptor works for streams.
+			{
+				streamClient := pbserverdiscovery.NewServerDiscoveryServiceClient(state.GRPCConn)
+				stream, err := streamClient.WatchServers(ctx, &pbserverdiscovery.WatchServersRequest{})
+				require.NoError(t, err)
+				resp, err := stream.Recv()
+				require.NoError(t, err)
+				require.Len(t, resp.Servers, len(serverAddrs))
+			}
+			t.Logf("test successful")
+		})
 	}
 
-	// Start the Watcher. This blocks until initialization is complete.
-	go w.Run()
-	t.Cleanup(w.Stop)
-
-	state, err := w.State()
-	require.NoError(t, err)
-	require.NotNil(t, state)
-	require.NotNil(t, state, state.GRPCConn)
-	require.Equal(t, state.Token, "")
-
-	// Make a gRPC request to check that the gRPC connection is working.
-	unaryClient := pbdataplane.NewDataplaneServiceClient(state.GRPCConn)
-	resp, err := unaryClient.GetSupportedDataplaneFeatures(ctx, &pbdataplane.GetSupportedDataplaneFeaturesRequest{})
-	require.NoError(t, err, "error from unary request")
-	require.NotNil(t, resp)
-
-	t.Logf("test successful")
 }
 
 // A custom Discoverer allows us to inject custom addresses with ports, so that
@@ -68,7 +115,7 @@ func (t *testDiscoverer) Discover(ctx context.Context) ([]Addr, error) {
 // consulServers starts a multi-server Consul test cluster. It returns map of the
 // server addresses (ip+port) to each server object, and the list of parsed
 // server gRPC addresses.
-func consulServers(t *testing.T, n int) (map[string]*testutil.TestServer, []Addr) {
+func consulServers(t *testing.T, n int, cb testutil.ServerConfigCallback) (map[string]*testutil.TestServer, []Addr) {
 	require.Greater(t, n, 0)
 
 	servers := map[string]*testutil.TestServer{}
@@ -80,7 +127,9 @@ func consulServers(t *testing.T, n int) (map[string]*testutil.TestServer, []Addr
 				addr := fmt.Sprintf("%s:%d", srv.Config.Bind, srv.Config.Ports.SerfLan)
 				c.RetryJoin = append(c.RetryJoin, addr)
 			}
-			// TODO: ACL config
+			if cb != nil {
+				cb(c)
+			}
 		})
 		require.NoError(t, err)
 		t.Cleanup(func() {
@@ -98,4 +147,10 @@ func consulServers(t *testing.T, n int) (map[string]*testutil.TestServer, []Addr
 		server.WaitForLeader(t)
 	}
 	return servers, addrs
+}
+
+func enableACLsConfigFn(c *testutil.TestServerConfig) {
+	c.ACL.Enabled = true
+	c.ACL.Tokens.InitialManagement = testServerManagementToken
+	c.ACL.DefaultPolicy = "deny"
 }


### PR DESCRIPTION
This adds custom gRPC interceptors that allow us to automatically support the following for all requests on the gRPC connection:

* Inject an ACL token to outgoing contexts, if an ACL token is configured on the watcher
* React to errors received over the gRPC connection. We'll use this to automatically switch servers when receiving "resource exhausted" status code (but the "switch servers" functionality is not added in this PR).

- [x] Depends on #2 