### PR TITLE
Infer TLS ServerName from hostname

### DIFF
--- a/discovery/config.go
+++ b/discovery/config.go
@@ -2,7 +2,6 @@ package discovery
 
 import (
 	"crypto/tls"
-	"net"
 	"strings"
 	"time"
 )
@@ -42,9 +41,9 @@ type Config struct {
 	// TLS contains the TLS settings to use for the gRPC connections to the
 	// Consul servers. By default this is nil, indicating that TLS is disabled.
 	//
-	// The ServerName field is automatically set if Addresses contains
-	// a DNS hostname. The ServerName field is only set if TLS and TLS
-	// verification are enabled and the ServerName field is empty.
+	// If unset, the ServerName field is automatically set if Addresses
+	// contains a DNS hostname. The ServerName field is only set if TLS and TLS
+	// verification are enabled.
 	TLS         *tls.Config
 	Credentials Credentials
 }
@@ -55,22 +54,12 @@ func (c Config) withDefaults() Config {
 	}
 
 	// Infer the ServerName field if a hostname is used in Addresses.
-	if c.TLS != nil && !c.TLS.InsecureSkipVerify && c.TLS.ServerName == "" && isPotentialHostname(c.Addresses) {
+	if c.TLS != nil && !c.TLS.InsecureSkipVerify && c.TLS.ServerName == "" && !strings.HasPrefix(c.Addresses, "exec=") {
 		c.TLS = c.TLS.Clone()
 		c.TLS.ServerName = c.Addresses
 	}
 
 	return c
-}
-
-// isPotentialHostname returns true if the addr is not an IP or "exec=" string,
-// and true otherwise. It may return true for something that is not actually a
-// valid hostname.
-func isPotentialHostname(addr string) bool {
-	if addr == "" || strings.HasPrefix(addr, "exec=") {
-		return false
-	}
-	return net.ParseIP(addr) == nil
 }
 
 type Credentials struct {

--- a/discovery/config_test.go
+++ b/discovery/config_test.go
@@ -38,7 +38,7 @@ func TestConfigDefaults(t *testing.T) {
 				},
 			},
 		},
-		"do not infer tls server name when address is ip": {
+		"infer tls server name when address is ip": {
 			cfg: Config{
 				Addresses: "1.2.3.4",
 				TLS:       &tls.Config{},
@@ -46,7 +46,9 @@ func TestConfigDefaults(t *testing.T) {
 			expCfg: Config{
 				Addresses:                   "1.2.3.4",
 				ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
-				TLS:                         &tls.Config{},
+				TLS: &tls.Config{
+					ServerName: "1.2.3.4",
+				},
 			},
 		},
 		"do not infer tls server name when address is exec command": {
@@ -98,31 +100,5 @@ func TestConfigDefaults(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require.Equal(t, c.expCfg, c.cfg.withDefaults())
 		})
-	}
-}
-
-func TestIsPotentialHostname(t *testing.T) {
-	// non-hostnames
-	for _, addr := range []string{
-		"",
-		"exec=",
-		"exec=1.2.3.4",
-		"1.2.3.4",
-		"::1",
-		"0:0:0:0:0:0:0:1",
-	} {
-		require.False(t, isPotentialHostname(addr), "addr=%q", addr)
-	}
-
-	// valid hostnames
-	for _, addr := range []string{
-		"exec", // no trailing '='. this could be a hostname.
-		"a",
-		"a.b",
-		"abc.tld",
-		"1.2.3.tld",
-		"1.2.3.4.tld",
-	} {
-		require.True(t, isPotentialHostname(addr), "addr=%q", addr)
 	}
 }

--- a/discovery/config_test.go
+++ b/discovery/config_test.go
@@ -1,0 +1,128 @@
+package discovery
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigDefaults(t *testing.T) {
+	cases := map[string]struct {
+		cfg, expCfg Config
+	}{
+		"default server watch disabled interval": {
+			cfg: Config{},
+			expCfg: Config{
+				ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
+			},
+		},
+		"custom server watch disabled interval": {
+			cfg: Config{
+				ServerWatchDisabledInterval: 1234,
+			},
+			expCfg: Config{
+				ServerWatchDisabledInterval: 1234,
+			},
+		},
+		"infer tls server name": {
+			cfg: Config{
+				Addresses: "my.host.name",
+				TLS:       &tls.Config{},
+			},
+			expCfg: Config{
+				Addresses:                   "my.host.name",
+				ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
+				TLS: &tls.Config{
+					ServerName: "my.host.name",
+				},
+			},
+		},
+		"do not infer tls server name when address is ip": {
+			cfg: Config{
+				Addresses: "1.2.3.4",
+				TLS:       &tls.Config{},
+			},
+			expCfg: Config{
+				Addresses:                   "1.2.3.4",
+				ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
+				TLS:                         &tls.Config{},
+			},
+		},
+		"do not infer tls server name when address is exec command": {
+			cfg: Config{
+				Addresses: "exec=./script.sh",
+				TLS:       &tls.Config{},
+			},
+			expCfg: Config{
+				Addresses:                   "exec=./script.sh",
+				ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
+				TLS:                         &tls.Config{},
+			},
+		},
+		"do not infer tls server name when TLS is disabled": {
+			cfg: Config{
+				Addresses: "my.host.name",
+				TLS:       nil,
+			},
+			expCfg: Config{
+				Addresses:                   "my.host.name",
+				ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
+			},
+		},
+		"do not infer tls server name when TLS verification is disabled": {
+			cfg: Config{
+				Addresses: "my.host.name",
+				TLS:       &tls.Config{InsecureSkipVerify: true},
+			},
+			expCfg: Config{
+				Addresses:                   "my.host.name",
+				ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
+				TLS:                         &tls.Config{InsecureSkipVerify: true},
+			},
+		},
+		"do not infer tls server name when already set": {
+			cfg: Config{
+				Addresses: "my.host.name",
+				TLS:       &tls.Config{ServerName: "other.host"},
+			},
+			expCfg: Config{
+				Addresses:                   "my.host.name",
+				ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
+				TLS:                         &tls.Config{ServerName: "other.host"},
+			},
+		},
+	}
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			require.Equal(t, c.expCfg, c.cfg.withDefaults())
+		})
+	}
+}
+
+func TestIsPotentialHostname(t *testing.T) {
+	// non-hostnames
+	for _, addr := range []string{
+		"",
+		"exec=",
+		"exec=1.2.3.4",
+		"1.2.3.4",
+		"::1",
+		"0:0:0:0:0:0:0:1",
+	} {
+		require.False(t, isPotentialHostname(addr), "addr=%q", addr)
+	}
+
+	// valid hostnames
+	for _, addr := range []string{
+		"exec", // no trailing '='. this could be a hostname.
+		"a",
+		"a.b",
+		"abc.tld",
+		"1.2.3.tld",
+		"1.2.3.4.tld",
+	} {
+		require.True(t, isPotentialHostname(addr), "addr=%q", addr)
+	}
+}


### PR DESCRIPTION
If `Addresses` is a hostname, then automatically set the `TLS.ServerName` field if TLS and TLS verification are enabled and the ServerName is unset.

- [x] Depends on #5 