### PR TITLE
Support custom server filtering

### DIFF
--- a/discovery/config.go
+++ b/discovery/config.go
@@ -38,6 +38,19 @@ type Config struct {
 	// This defaults to 1 minute.
 	ServerWatchDisabledInterval time.Duration
 
+	// ServerEvalFn is optional. It can be used to exclude servers based on
+	// custom criteria. If not nil, it is called after connecting to a server
+	// but prior to marking the server "current". When this returns false,
+	// the Watcher will skip the server.
+	//
+	// The State will be valid: The GRPCConn will be valid to use and
+	// DataplaneFeatures will be populated and the Address and Token (if
+	// applicable) will be set.
+	//
+	// This is called synchronously in the same goroutine as Watcher.Run(),
+	// so it should not block, or at least not for too long.
+	ServerEvalFn func(State) bool
+
 	// TLS contains the TLS settings to use for the gRPC connections to the
 	// Consul servers. By default this is nil, indicating that TLS is disabled.
 	//

--- a/discovery/config_test.go
+++ b/discovery/config_test.go
@@ -102,3 +102,39 @@ func TestConfigDefaults(t *testing.T) {
 		})
 	}
 }
+
+func TestSupportsDataplaneFeatures(t *testing.T) {
+	matchNone := SupportsDataplaneFeatures()
+	match1And2 := SupportsDataplaneFeatures("feat1", "feat2")
+
+	// No supported features.
+	{
+		state := State{}
+		require.True(t, matchNone(state))
+		require.False(t, match1And2(state))
+	}
+
+	// feat2 not supported.
+	{
+		state := State{
+			DataplaneFeatures: map[string]bool{
+				"feat1": true,
+				"feat2": false,
+			},
+		}
+		require.True(t, matchNone(state))
+		require.False(t, match1And2(state))
+	}
+
+	// Both feat1 and feat2 supported.
+	{
+		state := State{
+			DataplaneFeatures: map[string]bool{
+				"feat1": true,
+				"feat2": true,
+			},
+		}
+		require.True(t, matchNone(state))
+		require.True(t, match1And2(state))
+	}
+}


### PR DESCRIPTION
This adds a `ServerEvalFn` to the Watcher config that callers can set in order to reject servers based on their own criteria.