### PR TITLE
Expose concrete `*grpc.ClientConn` type rather than interface

### DIFF
--- a/discovery/watcher.go
+++ b/discovery/watcher.go
@@ -24,7 +24,7 @@ type InitState struct {
 	// automatically updated to switch to a new server, so you can
 	// use this connection for the lifetime of the associated
 	// Watcher.
-	GRPCConn grpc.ClientConnInterface
+	GRPCConn *grpc.ClientConn
 
 	// Token is the ACL token obtain from logging in (if applicable).
 	// If login is not supported this will be set to the static token


### PR DESCRIPTION
In consul-dataplane, we intend to use a [3rd party gRPC proxy module](https://github.com/adamthesax/grpc-proxy) which accepts the concrete type rather than the interface. While we could fork/submit a PR to the module, it doesn't make a huge amount of difference to us which type we expose, so let's change it here instead.
