### PR TITLE
Add connection_errors metric to the stream

### DIFF
--- a/discovery/interceptor.go
+++ b/discovery/interceptor.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"context"
 
+	"github.com/armon/go-metrics"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
@@ -86,11 +87,13 @@ func interceptError(watcher *Watcher, err error) {
 	if err == nil {
 		return
 	}
+	metrics.SetGauge([]string{"connection_errors"}, float32(1))
 
 	s, ok := status.FromError(err)
 	if !ok {
 		return
 	}
+	metrics.SetGaugeWithLabels([]string{"connection_errors"}, float32(1), []metrics.Label{{Name: "error_code", Value: s.Code().String()}})
 
 	if s.Code() == codes.ResourceExhausted {
 		watcher.log.Debug("saw gRPC ResourceExhausted status code")

--- a/discovery/stats.go
+++ b/discovery/stats.go
@@ -22,4 +22,8 @@ var Gauges = []prometheus.GaugeDefinition{
 		Name: []string{"consul_connected"},
 		Help: "This will either be 0 or 1 depending on whether the dataplane is currently connected to a Consul server.",
 	},
+	{
+		Name: []string{"connection_errors"},
+		Help: "This will track the number of errors encountered during the stream connection",
+	},
 }


### PR DESCRIPTION
This metric was requested to track the types of connection errors on the gRPC stream between the consul-dataplane and consul. 

Ex:
<img width="1056" alt="Screen Shot 2022-10-18 at 8 55 45 PM" src="https://user-images.githubusercontent.com/6537530/196594656-d74044e3-3924-4640-871c-aaf9e5474d03.png">
