### PR TITLE
Implement backoff reset

### DIFF
--- a/discovery/acl_test.go
+++ b/discovery/acl_test.go
@@ -123,5 +123,5 @@ func (a ACLMockFixture) SetupClientMock(t *testing.T) *ACLs {
 	if a.ExpLogoutRequest != nil {
 		client.Mock.On("Logout", ctx, a.ExpLogoutRequest).Return(a.LogoutResponse, a.LogoutErr)
 	}
-	return &ACLs{client: client, cfg: a.Config}
+	return &ACLs{client: client, cfg: a.Config, clock: &mockClock{}}
 }

--- a/discovery/config.go
+++ b/discovery/config.go
@@ -24,6 +24,7 @@ const (
 	DefaultBackOffMaxInterval         = 60 * time.Second
 	DefaultBackOffMultiplier          = 1.5
 	DefaultBackOffRandomizationFactor = 0.5
+	DefaultBackOffResetInterval       = 3 * DefaultBackOffMaxInterval
 )
 
 type Config struct {
@@ -134,12 +135,15 @@ type BackOffConfig struct {
 	// Multiplier is the factor by which the backoff retry interval increases on each subquent
 	// retry. Default: 1.5.
 	Multiplier float64
-	// MaxInterval is the maximum backoff interval for exponential backoff. Default: 60s.
+	// MaxInterval is the maximum backoff interval for exponential backoff. Default: 1m.
 	MaxInterval time.Duration
 	// RandomizationFactor randomizes the backoff retry interval using the formula:
 	//    RetryInterval * (random value in range [1-RandomizationFactor, 1+RandomizationFactor])
 	// Default: 0.5.
 	RandomizationFactor float64
+	// ResetInterval determines how long before resetting the backoff policy, If we are in a good
+	// state for at least this interval, then exponential backoff is reset. Default: 3m.
+	ResetInterval time.Duration
 }
 
 func (b BackOffConfig) withDefaults() BackOffConfig {
@@ -154,6 +158,9 @@ func (b BackOffConfig) withDefaults() BackOffConfig {
 	}
 	if b.RandomizationFactor == 0 {
 		b.RandomizationFactor = DefaultBackOffRandomizationFactor
+	}
+	if b.ResetInterval == 0 {
+		b.ResetInterval = DefaultBackOffResetInterval
 	}
 	return b
 }

--- a/discovery/config.go
+++ b/discovery/config.go
@@ -4,6 +4,8 @@ import (
 	"crypto/tls"
 	"strings"
 	"time"
+
+	"github.com/cenkalti/backoff/v4"
 )
 
 type ServerEvalFn func(State) bool
@@ -15,7 +17,14 @@ const (
 	CredentialsTypeLogin  CredentialsType = "login"
 )
 
-const DefaultServerWatchDisabledInterval = 1 * time.Minute
+const (
+	DefaultServerWatchDisabledInterval = 1 * time.Minute
+
+	DefaultBackOffInitialInterval     = 500 * time.Millisecond
+	DefaultBackOffMaxInterval         = 60 * time.Second
+	DefaultBackOffMultiplier          = 1.5
+	DefaultBackOffRandomizationFactor = 0.5
+)
 
 type Config struct {
 	// Addresses is a DNS name or exec command for go-netaddrs.
@@ -64,6 +73,8 @@ type Config struct {
 	// verification are enabled.
 	TLS         *tls.Config
 	Credentials Credentials
+
+	BackOff BackOffConfig
 }
 
 func (c Config) withDefaults() Config {
@@ -76,6 +87,8 @@ func (c Config) withDefaults() Config {
 		c.TLS = c.TLS.Clone()
 		c.TLS.ServerName = c.Addresses
 	}
+
+	c.BackOff = c.BackOff.withDefaults()
 
 	return c
 }
@@ -113,6 +126,47 @@ type LoginCredential struct {
 	// Meta is the arbitrary set of key-value pairs to attach to the
 	// token. These are included in the Description field of the token.
 	Meta map[string]string
+}
+
+type BackOffConfig struct {
+	// InitialInterval is initial backoff retry interval for exponential backoff. Default: 500ms.
+	InitialInterval time.Duration
+	// Multiplier is the factor by which the backoff retry interval increases on each subquent
+	// retry. Default: 1.5.
+	Multiplier float64
+	// MaxInterval is the maximum backoff interval for exponential backoff. Default: 60s.
+	MaxInterval time.Duration
+	// RandomizationFactor randomizes the backoff retry interval using the formula:
+	//    RetryInterval * (random value in range [1-RandomizationFactor, 1+RandomizationFactor])
+	// Default: 0.5.
+	RandomizationFactor float64
+}
+
+func (b BackOffConfig) withDefaults() BackOffConfig {
+	if b.InitialInterval == 0 {
+		b.InitialInterval = DefaultBackOffInitialInterval
+	}
+	if b.Multiplier == 0 {
+		b.Multiplier = DefaultBackOffMultiplier
+	}
+	if b.MaxInterval == 0 {
+		b.MaxInterval = DefaultBackOffMaxInterval
+	}
+	if b.RandomizationFactor == 0 {
+		b.RandomizationFactor = DefaultBackOffRandomizationFactor
+	}
+	return b
+}
+
+func (b BackOffConfig) getPolicy() backoff.BackOff {
+	result := backoff.NewExponentialBackOff()
+	result.InitialInterval = b.InitialInterval
+	result.MaxInterval = b.MaxInterval
+	result.Multiplier = b.Multiplier
+	result.RandomizationFactor = b.RandomizationFactor
+	// Backoff forever.
+	result.MaxElapsedTime = 0
+	return result
 }
 
 // SupportsDataplaneFeatures returns a ServerEvalFn that selects Consul servers

--- a/discovery/config_test.go
+++ b/discovery/config_test.go
@@ -4,25 +4,58 @@ import (
 	"crypto/tls"
 	"testing"
 
+	"github.com/cenkalti/backoff/v4"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 )
 
 func TestConfigDefaults(t *testing.T) {
+	makeDefaultConfig := func() Config {
+		return Config{
+			ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
+			BackOff: BackOffConfig{
+				InitialInterval:     DefaultBackOffInitialInterval,
+				Multiplier:          DefaultBackOffMultiplier,
+				MaxInterval:         DefaultBackOffMaxInterval,
+				RandomizationFactor: DefaultBackOffRandomizationFactor,
+			},
+		}
+	}
+
 	cases := map[string]struct {
-		cfg, expCfg Config
+		cfg Config
+		// this modifies the "base" default config from makeDefaults()
+		expCfgFn func(Config) Config
 	}{
 		"default server watch disabled interval": {
-			cfg: Config{},
-			expCfg: Config{
-				ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
-			},
+			cfg:      Config{},
+			expCfgFn: func(c Config) Config { return c },
 		},
 		"custom server watch disabled interval": {
 			cfg: Config{
 				ServerWatchDisabledInterval: 1234,
 			},
-			expCfg: Config{
-				ServerWatchDisabledInterval: 1234,
+			expCfgFn: func(c Config) Config {
+				c.ServerWatchDisabledInterval = 1234
+				return c
+			},
+		},
+		"custom backoff config": {
+			cfg: Config{
+				BackOff: BackOffConfig{
+					InitialInterval:     1,
+					Multiplier:          2,
+					MaxInterval:         3,
+					RandomizationFactor: 4,
+				},
+			},
+			expCfgFn: func(c Config) Config {
+				c.BackOff.InitialInterval = 1
+				c.BackOff.Multiplier = 2
+				c.BackOff.MaxInterval = 3
+				c.BackOff.RandomizationFactor = 4
+				return c
 			},
 		},
 		"infer tls server name": {
@@ -30,12 +63,10 @@ func TestConfigDefaults(t *testing.T) {
 				Addresses: "my.host.name",
 				TLS:       &tls.Config{},
 			},
-			expCfg: Config{
-				Addresses:                   "my.host.name",
-				ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
-				TLS: &tls.Config{
-					ServerName: "my.host.name",
-				},
+			expCfgFn: func(c Config) Config {
+				c.Addresses = "my.host.name"
+				c.TLS = &tls.Config{ServerName: "my.host.name"}
+				return c
 			},
 		},
 		"infer tls server name when address is ip": {
@@ -43,12 +74,10 @@ func TestConfigDefaults(t *testing.T) {
 				Addresses: "1.2.3.4",
 				TLS:       &tls.Config{},
 			},
-			expCfg: Config{
-				Addresses:                   "1.2.3.4",
-				ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
-				TLS: &tls.Config{
-					ServerName: "1.2.3.4",
-				},
+			expCfgFn: func(c Config) Config {
+				c.Addresses = "1.2.3.4"
+				c.TLS = &tls.Config{ServerName: "1.2.3.4"}
+				return c
 			},
 		},
 		"do not infer tls server name when address is exec command": {
@@ -56,10 +85,10 @@ func TestConfigDefaults(t *testing.T) {
 				Addresses: "exec=./script.sh",
 				TLS:       &tls.Config{},
 			},
-			expCfg: Config{
-				Addresses:                   "exec=./script.sh",
-				ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
-				TLS:                         &tls.Config{},
+			expCfgFn: func(c Config) Config {
+				c.Addresses = "exec=./script.sh"
+				c.TLS = &tls.Config{}
+				return c
 			},
 		},
 		"do not infer tls server name when TLS is disabled": {
@@ -67,9 +96,9 @@ func TestConfigDefaults(t *testing.T) {
 				Addresses: "my.host.name",
 				TLS:       nil,
 			},
-			expCfg: Config{
-				Addresses:                   "my.host.name",
-				ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
+			expCfgFn: func(c Config) Config {
+				c.Addresses = "my.host.name"
+				return c
 			},
 		},
 		"do not infer tls server name when TLS verification is disabled": {
@@ -77,10 +106,10 @@ func TestConfigDefaults(t *testing.T) {
 				Addresses: "my.host.name",
 				TLS:       &tls.Config{InsecureSkipVerify: true},
 			},
-			expCfg: Config{
-				Addresses:                   "my.host.name",
-				ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
-				TLS:                         &tls.Config{InsecureSkipVerify: true},
+			expCfgFn: func(c Config) Config {
+				c.Addresses = "my.host.name"
+				c.TLS = &tls.Config{InsecureSkipVerify: true}
+				return c
 			},
 		},
 		"do not infer tls server name when already set": {
@@ -88,17 +117,18 @@ func TestConfigDefaults(t *testing.T) {
 				Addresses: "my.host.name",
 				TLS:       &tls.Config{ServerName: "other.host"},
 			},
-			expCfg: Config{
-				Addresses:                   "my.host.name",
-				ServerWatchDisabledInterval: DefaultServerWatchDisabledInterval,
-				TLS:                         &tls.Config{ServerName: "other.host"},
+			expCfgFn: func(c Config) Config {
+				c.Addresses = "my.host.name"
+				c.TLS = &tls.Config{ServerName: "other.host"}
+				return c
 			},
 		},
 	}
 	for name, c := range cases {
 		c := c
 		t.Run(name, func(t *testing.T) {
-			require.Equal(t, c.expCfg, c.cfg.withDefaults())
+			expCfg := c.expCfgFn(makeDefaultConfig())
+			require.Equal(t, expCfg, c.cfg.withDefaults())
 		})
 	}
 }
@@ -137,4 +167,20 @@ func TestSupportsDataplaneFeatures(t *testing.T) {
 		require.True(t, matchNone(state))
 		require.True(t, match1And2(state))
 	}
+}
+
+func TestGetBackoffPolicy(t *testing.T) {
+	cfg := BackOffConfig{}.withDefaults()
+	bo := cfg.getPolicy()
+
+	exp := &backoff.ExponentialBackOff{
+		InitialInterval:     DefaultBackOffInitialInterval,
+		RandomizationFactor: DefaultBackOffRandomizationFactor,
+		Multiplier:          DefaultBackOffMultiplier,
+		MaxInterval:         DefaultBackOffMaxInterval,
+		MaxElapsedTime:      0,
+		Stop:                backoff.Stop,
+		Clock:               backoff.SystemClock,
+	}
+	require.Empty(t, cmp.Diff(bo, exp, cmpopts.IgnoreUnexported(*exp)))
 }

--- a/discovery/config_test.go
+++ b/discovery/config_test.go
@@ -19,6 +19,7 @@ func TestConfigDefaults(t *testing.T) {
 				Multiplier:          DefaultBackOffMultiplier,
 				MaxInterval:         DefaultBackOffMaxInterval,
 				RandomizationFactor: DefaultBackOffRandomizationFactor,
+				ResetInterval:       DefaultBackOffResetInterval,
 			},
 		}
 	}
@@ -48,6 +49,7 @@ func TestConfigDefaults(t *testing.T) {
 					Multiplier:          2,
 					MaxInterval:         3,
 					RandomizationFactor: 4,
+					ResetInterval:       5,
 				},
 			},
 			expCfgFn: func(c Config) Config {
@@ -55,6 +57,7 @@ func TestConfigDefaults(t *testing.T) {
 				c.BackOff.Multiplier = 2
 				c.BackOff.MaxInterval = 3
 				c.BackOff.RandomizationFactor = 4
+				c.BackOff.ResetInterval = 5
 				return c
 			},
 		},

--- a/discovery/discoverer.go
+++ b/discovery/discoverer.go
@@ -3,7 +3,6 @@ package discovery
 import (
 	"context"
 	"net"
-	"time"
 
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-hclog"
@@ -17,17 +16,19 @@ type Discoverer interface {
 type NetaddrsDiscoverer struct {
 	config Config
 	log    hclog.Logger
+	clock  Clock
 }
 
 func NewNetaddrsDiscoverer(config Config, log hclog.Logger) *NetaddrsDiscoverer {
 	return &NetaddrsDiscoverer{
 		config: config,
 		log:    log,
+		clock:  &SystemClock{},
 	}
 }
 
 func (n *NetaddrsDiscoverer) Discover(ctx context.Context) ([]Addr, error) {
-	start := time.Now()
+	start := n.clock.Now()
 	addrs, err := netaddrs.IPAddrs(ctx, n.config.Addresses, n.log)
 	if err != nil {
 		n.log.Error("discovering server addresses", "err", err)

--- a/discovery/time.go
+++ b/discovery/time.go
@@ -1,0 +1,25 @@
+package discovery
+
+import "time"
+
+type Clock interface {
+	Now() time.Time
+	After(d time.Duration) <-chan time.Time
+	Sleep(d time.Duration)
+}
+
+type SystemClock struct{}
+
+var _ Clock = (*SystemClock)(nil)
+
+func (*SystemClock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}
+
+func (*SystemClock) Now() time.Time {
+	return time.Now()
+}
+
+func (*SystemClock) Sleep(d time.Duration) {
+	time.Sleep(d)
+}

--- a/discovery/time_test.go
+++ b/discovery/time_test.go
@@ -1,0 +1,64 @@
+package discovery
+
+import (
+	"sync"
+	"time"
+)
+
+type mockClock struct {
+	sync.Mutex
+
+	t time.Time
+
+	// this stores
+	afterChans map[time.Time]chan time.Time
+}
+
+var _ Clock = (*mockClock)(nil)
+
+// You must call Sleep to advance the mock clock.
+func (f *mockClock) After(d time.Duration) <-chan time.Time {
+	f.Lock()
+	defer f.Unlock()
+
+	ch := make(chan time.Time, 1)
+	if d == 0 {
+		// Channel will immediately return on 0 duration.
+		ch <- f.t
+		close(ch)
+		return ch
+	} else {
+		// Otherwise, handle the send at the next Tick
+		end := f.t.Add(d)
+		f.afterChans[end] = ch
+	}
+	return ch
+}
+
+func (f *mockClock) Now() time.Time {
+	f.Lock()
+	defer f.Unlock()
+
+	return f.t
+}
+
+func (f *mockClock) Sleep(d time.Duration) {
+	f.Lock()
+	defer f.Unlock()
+
+	f.t = f.t.Add(d)
+
+	// Send to channels returned by After()
+	for end, ch := range f.afterChans {
+		if f.t.After(end) {
+			// non-blocking send
+			select {
+			case ch <- f.t:
+			default:
+			}
+
+			close(ch)
+			delete(f.afterChans, end)
+		}
+	}
+}

--- a/discovery/watcher.go
+++ b/discovery/watcher.go
@@ -89,16 +89,12 @@ func NewWatcher(ctx context.Context, config Config, log hclog.Logger) (*Watcher,
 		log = hclog.NewNullLogger()
 	}
 
-	// TODO: config for backoff values
-	backoff := backoff.NewExponentialBackOff()
-	backoff.MaxElapsedTime = 0 // Allow backing off forever.
-
 	config = config.withDefaults()
 
 	w := &Watcher{
 		config:       config,
 		log:          log,
-		backoff:      backoff,
+		backoff:      config.BackOff.getPolicy(),
 		resolver:     newResolver(log),
 		discoverer:   NewNetaddrsDiscoverer(config, log),
 		initComplete: newEvent(),

--- a/discovery/watcher_test.go
+++ b/discovery/watcher_test.go
@@ -2,11 +2,13 @@ package discovery
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/consul/proto-public/pbdataplane"
 	"github.com/hashicorp/consul/proto-public/pbserverdiscovery"
 	"github.com/hashicorp/consul/sdk/testutil"
@@ -186,6 +188,77 @@ func TestRun(t *testing.T) {
 			t.Logf("test successful")
 		})
 	}
+}
+
+func TestWatcherBackoffReset(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	clock := &mockClock{}
+	bo := &fakeBackOff{}
+
+	watcher := &Watcher{
+		ctx:       ctx,
+		ctxCancel: cancel,
+		config: Config{
+			BackOff: BackOffConfig{
+				ResetInterval: 10 * time.Second,
+			},
+		},
+		log:   hclog.NewNullLogger(),
+		clock: clock,
+	}
+
+	testEvents := []struct {
+		tick time.Duration
+		// note that backoff is reset following the call to nextServer
+		expBackOffResets int
+	}{
+		// ResetInterval is 10s.
+		{1 * time.Second, 0},          // 1s <= 10s: BackOff not reset
+		{9999 * time.Millisecond, 0},  // 9999ms <= 10s: BackOff not reset
+		{10001 * time.Millisecond, 0}, // 10001ms > 10s: BackOff will be reset
+		{1 * time.Second, 1},          // 1s <= 10s: BackOff not reset
+		{10 * time.Second, 1},         // 10s <= 10s: BackOff not reset
+		{11 * time.Second, 1},         // 11s > 10s: BackOff will be reset
+		{0 * time.Second, 2},
+	}
+
+	nextServerCount := 0
+	fakeNextServer := func(*addrSet) error {
+		if nextServerCount >= len(testEvents) {
+			cancel()
+			return fmt.Errorf("test over")
+		}
+
+		ev := testEvents[nextServerCount]
+		require.Equal(t, ev.expBackOffResets, bo.resetCount)
+		clock.Sleep(ev.tick)
+		t.Logf("t=%v : tick %s, resets %d", clock.t, ev.tick, bo.resetCount)
+
+		nextServerCount++
+
+		// we don't condition backoff reset on errors.
+		return errors.New("next server error")
+	}
+
+	watcher.run(bo, fakeNextServer)
+	// make sure fakeNextServer was called the correct number of times.
+	require.Equal(t, nextServerCount, len(testEvents))
+}
+
+type fakeBackOff struct {
+	resetCount int
+}
+
+var _ backoff.BackOff = (*fakeBackOff)(nil)
+
+func (f *fakeBackOff) NextBackOff() time.Duration {
+	return 0
+}
+
+func (f *fakeBackOff) Reset() {
+	f.resetCount++
 }
 
 func receiveSubscribeState(t *testing.T, ctx context.Context, ch <-chan State) State {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/armon/go-metrics v0.4.1
 	github.com/cenkalti/backoff/v4 v4.1.3
+	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/consul/proto-public v0.1.0
 	github.com/hashicorp/consul/sdk v0.11.0
 	github.com/hashicorp/go-hclog v1.2.2
@@ -19,7 +20,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.1 // indirect
@@ -39,6 +39,7 @@ require (
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
 	golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6 // indirect
 	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
This implements a time-based backoff reset. This works on the idea that being connected to a server is a "good" state so if we are connected to a server for long enough, then we reset the backoff.

----

Commit-by-commit review should be digestable

- https://github.com/hashicorp/consul-server-connection-manager/commit/5981ad97af70b1fcf80b0d26ec1cf66a9bd742a1 - Add exponential backoff config options: InitialInterval, MaxInterval, Multiplier, and RandomizationFactor
- https://github.com/hashicorp/consul-server-connection-manager/commit/4bd440d51a60df3aafdab3586868db0aacc3be8e - Add a Clock interface in order to mock time calls for tests
- https://github.com/hashicorp/consul-server-connection-manager/commit/19ae959f8ab9a7e31068d82c2977afb2bd8c2b91 - Use the Clock interface mostly everywhere. It is not immediately used by other tests, yet, so this is more just due diligence. There are also still certain time-based things not on the Clock interface here and there, because it was more than a few minutes of work to switch them over
- https://github.com/hashicorp/consul-server-connection-manager/commit/6b74eae74ef57a7c280abc869f77ca2ec9e2ce43 - Add a backoff config option for backoff reset: `ResetInterval`
- https://github.com/hashicorp/consul-server-connection-manager/commit/ecaba6de20b7fddbf880e0e239a82390a61062d6 - Implement backoff reset.