### PR TITLE
Prep for 0.1.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @hashicorp/consul-core

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,12 @@ jobs:
     strategy:
       matrix:
         consul-version:
-        - 1.13.1
+        - 1.14.0-beta1
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
     - name: Install Consul
       run: |
         CONSUL_VERSION="${{ matrix.consul-version }}"
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# WORK IN PROGRESS
-
-This library is still under development and hence subject to breaking changes.
+[![GoDoc](https://pkg.go.dev/badge/github.com/hashicorp/consul-server-connection-manager)](https://pkg.go.dev/github.com/hashicorp/consul-server-connection-manager)
 
 ## Summary
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/consul-server-connection-manager
 
-go 1.18
+go 1.19
 
 require (
 	github.com/armon/go-metrics v0.4.1
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/consul/proto-public v0.1.0
 	github.com/hashicorp/consul/sdk v0.11.0
 	github.com/hashicorp/go-hclog v1.2.2
-	github.com/hashicorp/go-netaddrs v0.0.0-20220509001840-90ed9d26ec46
+	github.com/hashicorp/go-netaddrs v0.1.0
 	github.com/stretchr/testify v1.7.2
 	google.golang.org/grpc v1.48.0
 )

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/hashicorp/go-hclog v1.2.2 h1:ihRI7YFwcZdiSD7SIenIhHfQH3OuDvWerAUBZbeQ
 github.com/hashicorp/go-hclog v1.2.2/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
-github.com/hashicorp/go-netaddrs v0.0.0-20220509001840-90ed9d26ec46 h1:BysEAd6g+0HNJ0v99u7KbSObjzxC7rfVQ6yVx6HxrvU=
-github.com/hashicorp/go-netaddrs v0.0.0-20220509001840-90ed9d26ec46/go.mod h1:TjKbv4FhIra0YJ82mws5+4QXOhzv09eAWs4jtOBI4IU=
+github.com/hashicorp/go-netaddrs v0.1.0 h1:TnlYvODD4C/wO+j7cX1z69kV5gOzI87u3OcUinANaW8=
+github.com/hashicorp/go-netaddrs v0.1.0/go.mod h1:33+a/emi5R5dqRspOuZKO0E+Tuz5WV1F84eRWALkedA=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=


### PR DESCRIPTION
* Test with consul 1.14.0-beta1
* Bump to go 1.19
* Set the go-netaddrs version to v0.1.0