### PR TITLE
Fix watcher Subscribe data race

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
           rm "${FILENAME}"
         consul version
     - name: Test
-      run: go test ./...
+      run: go test ./... -race
   golangci:
     name: lint
     runs-on: ubuntu-latest

--- a/discovery/watcher.go
+++ b/discovery/watcher.go
@@ -72,7 +72,8 @@ type Watcher struct {
 
 	acls *ACLs
 
-	subcribers []chan State
+	subcribers        []chan State
+	subscriptionMutex sync.RWMutex
 
 	// discoverer discovers IP addresses. In tests, we use mock this interface
 	// to inject custom server ports.
@@ -161,12 +162,18 @@ func NewWatcher(ctx context.Context, config Config, log hclog.Logger) (*Watcher,
 }
 
 func (w *Watcher) Subscribe() <-chan State {
+	w.subscriptionMutex.Lock()
+	defer w.subscriptionMutex.Unlock()
+
 	ch := make(chan State, 1)
 	w.subcribers = append(w.subcribers, ch)
 	return ch
 }
 
 func (w *Watcher) notifySubscribers() {
+	w.subscriptionMutex.RLock()
+	defer w.subscriptionMutex.RUnlock()
+
 	state := w.currentState()
 	for _, ch := range w.subcribers {
 		select {

--- a/discovery/watcher.go
+++ b/discovery/watcher.go
@@ -72,7 +72,7 @@ type Watcher struct {
 
 	acls *ACLs
 
-	subcribers        []chan State
+	subscribers       []chan State
 	subscriptionMutex sync.RWMutex
 
 	// discoverer discovers IP addresses. In tests, we use mock this interface
@@ -166,7 +166,7 @@ func (w *Watcher) Subscribe() <-chan State {
 	defer w.subscriptionMutex.Unlock()
 
 	ch := make(chan State, 1)
-	w.subcribers = append(w.subcribers, ch)
+	w.subscribers = append(w.subscribers, ch)
 	return ch
 }
 
@@ -175,7 +175,7 @@ func (w *Watcher) notifySubscribers() {
 	defer w.subscriptionMutex.RUnlock()
 
 	state := w.currentState()
-	for _, ch := range w.subcribers {
+	for _, ch := range w.subscribers {
 		select {
 		case ch <- state:
 			// success

--- a/discovery/watcher_test.go
+++ b/discovery/watcher_test.go
@@ -114,6 +114,10 @@ func TestRun(t *testing.T) {
 			// Get initial state. This blocks until initialization is complete.
 			initialState, err := w.State()
 			require.NoError(t, err)
+
+			// subscribe again for race detection
+			_ = w.Subscribe()
+
 			require.NotNil(t, initialState, initialState.GRPCConn)
 			require.Contains(t, servers.servers, initialState.Address.String())
 


### PR DESCRIPTION
So, there are actually a few data races in the library, especially when having multiple watchers (the case when running consul-api-gateway's tests in parallel) due to the way [balancer.Register](https://pkg.go.dev/google.golang.org/grpc/balancer#Register) is called when initializing a watcher. See:

> NOTE: this function must only be called during initialization time (i.e. in an init() function), and is not thread-safe. If multiple Balancers are registered with the same name, the one registered last will take effect.

This PR doesn't fix some of those wider issues, but there's also an internal `Watcher` race when the library is used as specified in the README for http clients, namely when `Subscribe` is called after the watcher starts.

This fixes that race by adding an additional `Subscribe` call to the tests and then implementing the fix with a `RWMutex`. Additionally to avoid regressions I enabled the `-race` flag in CI.