### PR TITLE
refactor to singleton gRPC load balancer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         consul-version:
-        - 1.14.0-beta1
+        - 1.14.3
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3

--- a/discovery/balancer.go
+++ b/discovery/balancer.go
@@ -39,7 +39,7 @@ type watcherBalancer struct {
 
 	log hclog.Logger
 
-	cc         clientConnWrapper
+	cc         *clientConnWrapper
 	subConn    balancer.SubConn
 	state      connectivity.State
 	activeAddr resolver.Address
@@ -173,6 +173,8 @@ func (b *watcherBalancer) hasTransitioned(to Addr) error {
 // exponential backoff until a subsequent call to UpdateClientConnState
 // returns a nil error.  Any other errors are currently ignored.
 func (b *watcherBalancer) UpdateClientConnState(state balancer.ClientConnState) error {
+	b.log.Trace("watcherBalancer.UpdateClientConnState", state)
+
 	for _, a := range state.ResolverState.Addresses {
 		// This hack preserves an existing behavior in our client-side
 		// load balancing where if the first address in a shuffled list

--- a/discovery/balancer.go
+++ b/discovery/balancer.go
@@ -134,6 +134,7 @@ func (b *watcherBalancer) WaitForTransition(ctx context.Context, to Addr) error 
 
 // hasTransitioned checks if we've finished transitioning to the given address.
 func (b *watcherBalancer) hasTransitioned(to Addr) error {
+	// FIXME: this panics because w.balancer is not initialized anymore
 	b.cc.lock.Lock()
 	defer b.cc.lock.Unlock()
 
@@ -173,7 +174,7 @@ func (b *watcherBalancer) hasTransitioned(to Addr) error {
 // exponential backoff until a subsequent call to UpdateClientConnState
 // returns a nil error.  Any other errors are currently ignored.
 func (b *watcherBalancer) UpdateClientConnState(state balancer.ClientConnState) error {
-	b.log.Trace("watcherBalancer.UpdateClientConnState", state)
+	b.log.Trace("balancer.UpdateClientConnState", "state", state)
 
 	for _, a := range state.ResolverState.Addresses {
 		// This hack preserves an existing behavior in our client-side

--- a/discovery/balancer_builder.go
+++ b/discovery/balancer_builder.go
@@ -12,8 +12,9 @@ import (
 // balancerBuilder is invoked by gRPC to construct our custom balancer. This
 // handles the hook up of the balancer to a Watcher.
 type balancerBuilder struct {
-	watcher *Watcher
-	log     hclog.Logger
+	// watcher *Watcher
+	// log hclog.Logger
+	log func() hclog.Logger
 
 	// This is the unique id for this builder in gRPC global balancer registry,
 	// used as the loadBalancingPolicy name when configuring a gRPC connection.
@@ -26,11 +27,12 @@ var _ balancer.Builder = (*balancerBuilder)(nil)
 // Balancers must be globally registered and cannot be unregistered, so we register each builder
 // with a unique id to facilitate testing. This returns the loadBalancingPolicy name used to enable
 // this balancer on a gRPC connection.
-func registerBalancer(w *Watcher, log hclog.Logger) string {
+func registerBalancer(log func() hclog.Logger) string {
 	b := &balancerBuilder{
-		watcher:        w,
-		log:            log,
-		hackPolicyName: randomString(),
+		// watcher: w,
+		log: log,
+		// hackPolicyName: randomString(),
+		hackPolicyName: "consul-server-connection-manager",
 	}
 	balancer.Register(b)
 	return b.hackPolicyName
@@ -45,7 +47,7 @@ func (b *balancerBuilder) Name() string {
 // Since we grpc.Dial one time in the Watcher, this is called only the first time a sub-connection
 // needs to be created (so after the resolver first sets an address on the connection).
 func (b *balancerBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) balancer.Balancer {
-	b.log.Trace("balancerBuilder.Build")
+	b.log().Trace("balancerBuilder.Build")
 
 	blr := &watcherBalancer{
 		log: b.log,
@@ -56,9 +58,8 @@ func (b *balancerBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOption
 	baseBuilder := base.NewBalancerBuilder(b.hackPolicyName, blr, base.Config{})
 	blr.Balancer = baseBuilder.Build(ccWrapper, opt)
 
-	b.watcher.balancer = blr
-	return b.watcher.balancer
-
+	// b.watcher.balancer = blr
+	return blr
 }
 
 // randomString returns a 32-byte hex-encoded string.

--- a/discovery/balancer_builder.go
+++ b/discovery/balancer_builder.go
@@ -3,7 +3,6 @@ package discovery
 import (
 	// "crypto/rand"
 	// "encoding/hex"
-	"fmt"
 
 	"github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc/balancer"

--- a/discovery/balancer_builder.go
+++ b/discovery/balancer_builder.go
@@ -1,8 +1,8 @@
 package discovery
 
 import (
-	"crypto/rand"
-	"encoding/hex"
+	// "crypto/rand"
+	// "encoding/hex"
 
 	"github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc/balancer"

--- a/discovery/balancer_builder.go
+++ b/discovery/balancer_builder.go
@@ -65,7 +65,8 @@ func (b *watcherBalancerBuilder) Build(cc balancer.ClientConn, opt balancer.Buil
 	}
 
 	return &watcherBalancer{
-		cc:       ccWrapper,
+		log:      b.log,
+		cc:       &ccWrapper,
 		Balancer: b.baseBuilder.Build(&ccWrapper, opt),
 	}
 }

--- a/discovery/balancer_builder.go
+++ b/discovery/balancer_builder.go
@@ -63,13 +63,13 @@ func (b *watcherBalancerBuilder) Build(cc balancer.ClientConn, opt balancer.Buil
 		log:        b.log,
 	}
 
-	blr := watcherBalancer{
+	blr := &watcherBalancer{
 		cc:       ccWrapper,
 		scs:      map[balancer.SubConn]*subConnState{},
 		Balancer: b.baseBuilder.Build(&ccWrapper, opt),
 	}
 
-	blr.cc.balancer = &blr
+	blr.cc.balancer = blr
 
-	return blr.cc.balancer
+	return blr
 }

--- a/discovery/balancer_builder.go
+++ b/discovery/balancer_builder.go
@@ -63,10 +63,10 @@ func (b *balancerBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOption
 }
 
 // randomString returns a 32-byte hex-encoded string.
-func randomString() string {
-	b := make([]byte, 32)
-	if _, err := rand.Read(b); err != nil {
-		panic("failed to generate random bytes")
-	}
-	return hex.EncodeToString(b)
-}
+// func randomString() string {
+// 	b := make([]byte, 32)
+// 	if _, err := rand.Read(b); err != nil {
+// 		panic("failed to generate random bytes")
+// 	}
+// 	return hex.EncodeToString(b)
+// }

--- a/discovery/balancer_builder.go
+++ b/discovery/balancer_builder.go
@@ -3,70 +3,73 @@ package discovery
 import (
 	// "crypto/rand"
 	// "encoding/hex"
+	"fmt"
 
 	"github.com/hashicorp/go-hclog"
 	"google.golang.org/grpc/balancer"
 	"google.golang.org/grpc/balancer/base"
 )
 
-// balancerBuilder is invoked by gRPC to construct our custom balancer. This
-// handles the hook up of the balancer to a Watcher.
-type balancerBuilder struct {
-	// watcher *Watcher
-	// log hclog.Logger
-	log func() hclog.Logger
-
-	// This is the unique id for this builder in gRPC global balancer registry,
-	// used as the loadBalancingPolicy name when configuring a gRPC connection.
-	hackPolicyName string
+// init creates a new watcherBalancerBuilder and registers it with gRPC.
+// Balancers must be globally registered and cannot be unregistered and registration is
+// not threadsafe so must happen in an init() function.
+func init() {
+	balancer.Register(newWatcherBalancerBuilder())
 }
 
-var _ balancer.Builder = (*balancerBuilder)(nil)
+// newWatcherBalancerBuilder can only safely be called in init() because
+// base.NewBalancerBuilder is not threadsafe
+func newWatcherBalancerBuilder() balancer.Builder {
+	log := hclog.New(&hclog.LoggerOptions{
+		Name: fmt.Sprintf("watcherBalancerBuilder"),
 
-// registerBalancer creates new balancer.Builder for the given Watcher and registers it with gRPC.
-// Balancers must be globally registered and cannot be unregistered, so we register each builder
-// with a unique id to facilitate testing. This returns the loadBalancingPolicy name used to enable
-// this balancer on a gRPC connection.
-func registerBalancer(log func() hclog.Logger) string {
-	b := &balancerBuilder{
-		// watcher: w,
+		// TODO: customize log level at init somehow?
+		Level: hclog.Trace,
+	})
+
+	pb := &pickerBuilder{
 		log: log,
-		// hackPolicyName: randomString(),
-		hackPolicyName: "consul-server-connection-manager",
 	}
-	balancer.Register(b)
-	return b.hackPolicyName
+
+	wbb := watcherBalancerBuilder{log: log}
+	wbb.baseBuilder = base.NewBalancerBuilder(wbb.Name(), pb, base.Config{})
+
+	return &wbb
 }
 
-func (b *balancerBuilder) Name() string {
-	return b.hackPolicyName
+// watcherBalancerBuilder is invoked by gRPC to construct our custom balancer. This
+// handles the hook up of the balancer to a Watcher.
+type watcherBalancerBuilder struct {
+	log hclog.Logger
+
+	baseBuilder balancer.Builder
 }
+
+func (*watcherBalancerBuilder) Name() string {
+	return "consul-server-connection-manager"
+}
+
+var _ balancer.Builder = (*watcherBalancerBuilder)(nil)
 
 // Build constructs a balancer. This hooks up the balancer to the Watcher when it is created.
 //
 // Since we grpc.Dial one time in the Watcher, this is called only the first time a sub-connection
 // needs to be created (so after the resolver first sets an address on the connection).
-func (b *balancerBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) balancer.Balancer {
-	b.log().Trace("balancerBuilder.Build")
+func (b *watcherBalancerBuilder) Build(cc balancer.ClientConn, opt balancer.BuildOptions) balancer.Balancer {
+	b.log.Trace("balancerBuilder.Build")
 
-	blr := &watcherBalancer{
-		log: b.log,
-		scs: map[balancer.SubConn]*subConnState{},
+	ccWrapper := clientConnWrapper{
+		ClientConn: cc,
+		log:        b.log,
 	}
-	ccWrapper := &clientConnWrapper{ClientConn: cc, balancer: blr, log: b.log}
 
-	baseBuilder := base.NewBalancerBuilder(b.hackPolicyName, blr, base.Config{})
-	blr.Balancer = baseBuilder.Build(ccWrapper, opt)
+	blr := watcherBalancer{
+		cc:       ccWrapper,
+		scs:      map[balancer.SubConn]*subConnState{},
+		Balancer: b.baseBuilder.Build(&ccWrapper, opt),
+	}
 
-	// b.watcher.balancer = blr
-	return blr
+	blr.cc.balancer = &blr
+
+	return blr.cc.balancer
 }
-
-// randomString returns a 32-byte hex-encoded string.
-// func randomString() string {
-// 	b := make([]byte, 32)
-// 	if _, err := rand.Read(b); err != nil {
-// 		panic("failed to generate random bytes")
-// 	}
-// 	return hex.EncodeToString(b)
-// }

--- a/discovery/balancer_builder.go
+++ b/discovery/balancer_builder.go
@@ -60,16 +60,12 @@ func (b *watcherBalancerBuilder) Build(cc balancer.ClientConn, opt balancer.Buil
 
 	ccWrapper := clientConnWrapper{
 		ClientConn: cc,
+		scs:        map[balancer.SubConn]*subConnState{},
 		log:        b.log,
 	}
 
-	blr := &watcherBalancer{
+	return &watcherBalancer{
 		cc:       ccWrapper,
-		scs:      map[balancer.SubConn]*subConnState{},
 		Balancer: b.baseBuilder.Build(&ccWrapper, opt),
 	}
-
-	blr.cc.balancer = blr
-
-	return blr
 }

--- a/discovery/balancer_builder.go
+++ b/discovery/balancer_builder.go
@@ -21,7 +21,7 @@ func init() {
 // base.NewBalancerBuilder is not threadsafe
 func newWatcherBalancerBuilder() balancer.Builder {
 	log := hclog.New(&hclog.LoggerOptions{
-		Name: fmt.Sprintf("watcherBalancerBuilder"),
+		Name: "watcherBalancerBuilder",
 
 		// TODO: customize log level at init somehow?
 		Level: hclog.Trace,

--- a/discovery/balancer_test.go
+++ b/discovery/balancer_test.go
@@ -175,16 +175,17 @@ func mustMakeAddr(t *testing.T, addr string, port int) Addr {
 func makeBalancerBuilder(t *testing.T, watcher *Watcher) *watcherBalancer {
 	t.Helper()
 
-	hackPolicyId := registerBalancer(watcher, watcher.log)
+	hackPolicyId := registerBalancer(func() hclog.Logger { return watcher.log })
 
 	builder := balancer.Get(hackPolicyId)
 	require.IsType(t, &balancerBuilder{}, builder)
-	bb := builder.(*balancerBuilder)
-	require.Equal(t, watcher, bb.watcher)
+	// bb := builder.(*balancerBuilder)
+	// require.Equal(t, watcher, bb.watcher)
 
 	// Build is called by gRPC normally.
 	wb := builder.Build(&fakeBalancerClientConn{}, balancer.BuildOptions{})
-	require.Equal(t, wb, watcher.balancer)
+	watcher.balancer = wb.(*watcherBalancer)
+	// require.Equal(t, wb, watcher.balancer)
 	require.IsType(t, &watcherBalancer{}, wb)
 
 	return wb.(*watcherBalancer)

--- a/discovery/balancer_test.go
+++ b/discovery/balancer_test.go
@@ -175,10 +175,11 @@ func mustMakeAddr(t *testing.T, addr string, port int) Addr {
 func makeBalancerBuilder(t *testing.T, watcher *Watcher) *watcherBalancer {
 	t.Helper()
 
-	hackPolicyId := registerBalancer(func() hclog.Logger { return watcher.log })
+	// hackPolicyId := registerBalancer(func() hclog.Logger { return watcher.log })
 
-	builder := balancer.Get(hackPolicyId)
-	require.IsType(t, &balancerBuilder{}, builder)
+	// TODO: some way to not hardcode this?
+	builder := balancer.Get("consul-server-connection-manager")
+	require.IsType(t, &watcherBalancerBuilder{}, builder)
 	// bb := builder.(*balancerBuilder)
 	// require.Equal(t, watcher, bb.watcher)
 

--- a/discovery/balancer_test.go
+++ b/discovery/balancer_test.go
@@ -47,7 +47,7 @@ func TestBalancerOneAddress(t *testing.T) {
 	require.NoError(t, err)
 
 	// Initially there are no sub-connections.
-	err = blr.hasTransitioned(addr)
+	err = blr.cc.hasTransitioned(addr)
 	require.Error(t, err)
 	require.Equal(t, "no known sub-connections", err.Error())
 
@@ -208,7 +208,7 @@ func requireSubConnState(t *testing.T, wb *watcherBalancer, sc balancer.SubConn,
 	require.Equal(t, wb.cc.scs[sc].state.ConnectivityState, state)
 	require.Equal(t, wb.cc.scs[sc].addr.Addr, addr.String())
 
-	err := wb.hasTransitioned(addr)
+	err := wb.cc.hasTransitioned(addr)
 	if transitionErr != "" {
 		require.Error(t, err)
 		require.Contains(t, err.Error(), transitionErr)

--- a/discovery/picker.go
+++ b/discovery/picker.go
@@ -1,0 +1,106 @@
+package discovery
+
+import (
+	"fmt"
+	// "sync"
+
+	"github.com/hashicorp/go-hclog"
+	"google.golang.org/grpc/balancer"
+	"google.golang.org/grpc/balancer/base"
+	// "google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/resolver"
+)
+
+// TODO: Is a PickerBuilder implementation only needed for the argument to
+// base.NewBalancerBuilder?
+type pickerBuilder struct {
+	log hclog.Logger
+}
+
+// This implements a custom gRPC PickerBuilder and Picker.
+type picker struct {
+	log hclog.Logger
+
+	// the singular SubConn used to construct this picker, which will always be picked
+	result balancer.PickResult
+
+	// the address used to create the result SubConn
+	address resolver.Address
+
+	err error
+}
+
+// Ensure our pickerBuilderPicker implements the gRPC PickerBuilder and Picker interfaces
+var _ base.PickerBuilder = (*pickerBuilder)(nil)
+var _ balancer.Picker = (*picker)(nil)
+
+// Build implements base.PickerBuilder
+//
+// This is called by the base Balancer when the set of ready sub-connections
+// has changed.
+func (pb *pickerBuilder) Build(info base.PickerBuildInfo) balancer.Picker {
+	pb.log.Trace("pickerBuilder.Build", "sub-conns ready", len(info.ReadySCs))
+
+	// p.lock.Lock()
+	// defer p.lock.Unlock()
+
+	for sc, info := range info.ReadySCs {
+		// Return a picker which always selects first ready SubConn
+		return &picker{
+			log:     pb.log,
+			result:  balancer.PickResult{SubConn: sc},
+			address: info.Address,
+		}
+
+		// TODO: only SubConns in "READY" state should ever be passed into the
+		// PickerBuilder Build call, and this impl is trying to ensure only a single
+		// SubConn is ever passed, did updating this state serve some other purpose?
+		//
+		// This should be duplicative now since we already implement this between
+		// clientConnWrapper.NewSubConn, clientConnWrapper.UpdateAddresses and
+		// watcherBalancer.UpdateSubConnState?
+		//
+		// 	_, ok := p.scs[sc]
+		// 	if !ok {
+		// 		p.scs[sc] = &subConnState{}
+		// 	}
+		//
+		// 	p.scs[sc].addr = info.Address
+		// 	p.scs[sc].state.ConnectivityState = connectivity.Ready
+	}
+
+	// If no ready SubConns are passed to Build, return a picker which will always have
+	// an error state
+	return &picker{
+		log:    pb.log,
+		result: balancer.PickResult{},
+		err:    fmt.Errorf("no ready sub-connections"),
+	}
+}
+
+// Pick implements balancer.Picker
+//
+// This is called prior to each gRPC message to choose the sub-conn to use.
+// This always picks the ready sub-connection from which the picker was created.
+func (p *picker) Pick(balancer.PickInfo) (balancer.PickResult, error) {
+	p.log.Trace("picker.Pick", p.address, p.err)
+
+	return p.result, p.err
+}
+
+// Pick implements balancer.Picker
+//
+// This is called prior to each gRPC message to choose the sub-conn to use.
+// This picks any ready sub-connection.
+// func (p *pickerBuilderPicker) Pick(info balancer.PickInfo) (balancer.PickResult, error) {
+// 	p.lock.Lock()
+// 	defer p.lock.Unlock()
+
+// 	// Pick any READY address.
+// 	for sc, state := range p.scs {
+// 		if state.state.ConnectivityState == connectivity.Ready {
+// 			return balancer.PickResult{SubConn: sc}, nil
+// 		}
+// 	}
+// 	return balancer.PickResult{}, fmt.Errorf("no ready sub-connections")
+// }

--- a/discovery/resolver.go
+++ b/discovery/resolver.go
@@ -79,5 +79,5 @@ func (r *watcherResolver) Close() {}
 // again. It's just a hint, resolver can ignore this if it's not necessary.
 // It could be called multiple times concurrently."
 func (r *watcherResolver) ResolveNow(_ resolver.ResolveNowOptions) {
-	r.cc.WaitForTransition(context.Background(), r.addr)
+	_ = r.cc.WaitForTransition(context.Background(), r.addr)
 }

--- a/discovery/watcher.go
+++ b/discovery/watcher.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/status"
 )
 
@@ -471,8 +472,8 @@ func (w *Watcher) switchServer(to Addr) error {
 	if err != nil {
 		return err
 	}
-	// FIXME: with the refactor, w.balancer is no longer set properly
-	return w.balancer.WaitForTransition(w.ctx, to)
+	w.resolver.ResolveNow(resolver.ResolveNowOptions{})
+	return nil
 }
 
 // requestServerSwitch requests a switch to some other server. This is safe to

--- a/discovery/watcher.go
+++ b/discovery/watcher.go
@@ -92,7 +92,7 @@ type serverState struct {
 }
 
 func NewWatcher(ctx context.Context, config Config, log hclog.Logger) (*Watcher, error) {
-	if log != nil {
+	if log == nil {
 		log = hclog.NewNullLogger()
 	}
 

--- a/discovery/watcher.go
+++ b/discovery/watcher.go
@@ -145,13 +145,15 @@ func NewWatcher(ctx context.Context, config Config, log hclog.Logger) (*Watcher,
 		// note: experimental apis
 		grpc.WithResolvers(w.resolver),
 		grpc.WithDefaultServiceConfig(
-			fmt.Sprintf(`{"loadBalancingPolicy": "%s"}`, "FIXME"),
+			fmt.Sprintf(`{"loadBalancingPolicy": "%s"}`, "consul-server-connection-manager"),
 		),
 	}
 
 	// Dial with "consul://" to trigger our custom resolver. We don't
 	// provide a server address. The connection will be updated by the
 	// Watcher via the custom resolver once an address is known.
+	//
+	// FIXME: need to add a ref from the watcher to either the balancer or clientConnWrapper somehow
 	conn, err := grpc.DialContext(w.ctx, "consul://", dialOpts...)
 	if err != nil {
 		return nil, err

--- a/discovery/watcher.go
+++ b/discovery/watcher.go
@@ -469,6 +469,7 @@ func (w *Watcher) switchServer(to Addr) error {
 	if err != nil {
 		return err
 	}
+	// FIXME: with the refactor, w.balancer is no longer set properly
 	return w.balancer.WaitForTransition(w.ctx, to)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/consul/proto-public v0.1.0
-	github.com/hashicorp/consul/sdk v0.11.0
+	github.com/hashicorp/consul/sdk v0.13.0
 	github.com/hashicorp/go-hclog v1.2.2
 	github.com/hashicorp/go-netaddrs v0.1.0
 	github.com/stretchr/testify v1.7.2
@@ -23,6 +23,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
 	github.com/hashicorp/go-immutable-radix v1.0.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.1 // indirect
+	github.com/hashicorp/go-version v1.2.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/kr/text v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/hashicorp/consul/proto-public v0.1.0 h1:O0LSmCqydZi363hsqc6n2v5sMz3us
 github.com/hashicorp/consul/proto-public v0.1.0/go.mod h1:vs2KkuWwtjkIgA5ezp4YKPzQp4GitV+q/+PvksrA92k=
 github.com/hashicorp/consul/sdk v0.11.0 h1:HRzj8YSCln2yGgCumN5CL8lYlD3gBurnervJRJAZyC4=
 github.com/hashicorp/consul/sdk v0.11.0/go.mod h1:yPkX5Q6CsxTFMjQQDJwzeNmUUF5NUGGbrDsv9wTb8cw=
+github.com/hashicorp/consul/sdk v0.13.0 h1:lce3nFlpv8humJL8rNrrGHYSKc3q+Kxfeg3Ii1m6ZWU=
+github.com/hashicorp/consul/sdk v0.13.0/go.mod h1:0hs/l5fOVhJy/VdcoaNqUSi2AUs95eF5WKtv+EYIQqE=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
@@ -95,6 +97,8 @@ github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-version v1.2.1 h1:zEfKbn2+PDgroKdiOzqiE8rsmLqU2uwi5PB5pBJ3TkI=
+github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=


### PR DESCRIPTION
Refs #23 

Updates [balancer.Register()](https://pkg.go.dev/google.golang.org/grpc/balancer#Register) to only happen once, during initialization, rather than in `NewWatcher()`

> NOTE: this function must only be called during initialization time (i.e. in an init() function), and is not thread-safe. If multiple Balancers are registered with the same name, the one registered last will take effect. 
