### PR TITLE
Introduce hashicorp/go-metrics compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
-          version: v1.57.2
+          version: v1.63.4
 
   # This is job is required for branch protection as a required GitHub check
   # because GitHub actions show up as checks at the job level and not the

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,22 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+run:
+  deadline: 5m
+
+linters-settings:
+  depguard:
+    rules:
+      main:
+        list-mode: lax
+        allow:
+          - "github.com/hashicorp/go-metrics/compat"
+        deny:
+          - pkg: "github.com/hashicorp/go-metrics"
+            desc: not allowed, use github.com/hashicorp/go-metrics/compat instead
+          - pkg: "github.com/armon/go-metrics"
+            desc: not allowed, use github.com/hashicorp/go-metrics/compat instead
+
+linters:
+  enable:
+    - depguard

--- a/discovery/acl.go
+++ b/discovery/acl.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/proto-public/pbacl"
+	"github.com/hashicorp/go-metrics/compat"
 	"google.golang.org/grpc"
 )
 

--- a/discovery/discoverer.go
+++ b/discovery/discoverer.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"net"
 
-	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-metrics/compat"
 	"github.com/hashicorp/go-netaddrs"
 )
 

--- a/discovery/interceptor.go
+++ b/discovery/interceptor.go
@@ -6,7 +6,7 @@ package discovery
 import (
 	"context"
 
-	"github.com/armon/go-metrics"
+	"github.com/hashicorp/go-metrics/compat"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"

--- a/discovery/stats.go
+++ b/discovery/stats.go
@@ -3,7 +3,7 @@
 
 package discovery
 
-import "github.com/armon/go-metrics/prometheus"
+import "github.com/hashicorp/go-metrics/compat/prometheus"
 
 var Summaries = []prometheus.SummaryDefinition{
 	{

--- a/discovery/watcher.go
+++ b/discovery/watcher.go
@@ -11,11 +11,11 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/armon/go-metrics"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/hashicorp/consul/proto-public/pbdataplane"
 	"github.com/hashicorp/consul/proto-public/pbserverdiscovery"
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-metrics/compat"
 	"google.golang.org/grpc"
 	backoff2 "google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/codes"

--- a/go.mod
+++ b/go.mod
@@ -3,18 +3,19 @@ module github.com/hashicorp/consul-server-connection-manager
 go 1.20
 
 require (
-	github.com/armon/go-metrics v0.4.1
 	github.com/cenkalti/backoff/v4 v4.1.3
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/consul/proto-public v0.6.2
 	github.com/hashicorp/consul/sdk v0.16.1
 	github.com/hashicorp/go-hclog v1.5.0
+	github.com/hashicorp/go-metrics v0.5.4-0.20241111182750-ceaacca141e7
 	github.com/hashicorp/go-netaddrs v0.1.0
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/grpc v1.56.3
 )
 
 require (
+	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/consul/proto-public v0.6.2
 	github.com/hashicorp/consul/sdk v0.16.1
 	github.com/hashicorp/go-hclog v1.5.0
-	github.com/hashicorp/go-metrics v0.5.4-0.20241111182750-ceaacca141e7
+	github.com/hashicorp/go-metrics v0.5.4
 	github.com/hashicorp/go-netaddrs v0.1.0
 	github.com/stretchr/testify v1.9.0
 	google.golang.org/grpc v1.56.3

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+
 github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
-github.com/hashicorp/go-metrics v0.5.4-0.20241111182750-ceaacca141e7 h1:yHXDz5riCB4wT/jNAO7URin5Si9EQF3Pf7iZ/r0yFnk=
-github.com/hashicorp/go-metrics v0.5.4-0.20241111182750-ceaacca141e7/go.mod h1:CG5yz4NZ/AI/aQt9Ucm/vdBnbh7fvmv4lxZ350i+QQI=
+github.com/hashicorp/go-metrics v0.5.4 h1:8mmPiIJkTPPEbAiV97IxdAGNdRdaWwVap1BU6elejKY=
+github.com/hashicorp/go-metrics v0.5.4/go.mod h1:CG5yz4NZ/AI/aQt9Ucm/vdBnbh7fvmv4lxZ350i+QQI=
 github.com/hashicorp/go-netaddrs v0.1.0 h1:TnlYvODD4C/wO+j7cX1z69kV5gOzI87u3OcUinANaW8=
 github.com/hashicorp/go-netaddrs v0.1.0/go.mod h1:33+a/emi5R5dqRspOuZKO0E+Tuz5WV1F84eRWALkedA=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/hashicorp/go-hclog v1.5.0 h1:bI2ocEMgcVlz55Oj1xZNBsVi900c7II+fWDyV9o+
 github.com/hashicorp/go-hclog v1.5.0/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
+github.com/hashicorp/go-metrics v0.5.4-0.20241111182750-ceaacca141e7 h1:yHXDz5riCB4wT/jNAO7URin5Si9EQF3Pf7iZ/r0yFnk=
+github.com/hashicorp/go-metrics v0.5.4-0.20241111182750-ceaacca141e7/go.mod h1:CG5yz4NZ/AI/aQt9Ucm/vdBnbh7fvmv4lxZ350i+QQI=
 github.com/hashicorp/go-netaddrs v0.1.0 h1:TnlYvODD4C/wO+j7cX1z69kV5gOzI87u3OcUinANaW8=
 github.com/hashicorp/go-netaddrs v0.1.0/go.mod h1:33+a/emi5R5dqRspOuZKO0E+Tuz5WV1F84eRWALkedA=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=


### PR DESCRIPTION
This PR migrates the library to using `github.com/hashicorp/go-metrics/compat` instead of `github.com/armon/go-metrics`.

Applications consuming the library can control whether metrics get emitted to either `armon/go-metrics` or `hashicorp/go-metrics` by specifying either the `armonmetrics` or `hashicorpmetrics` build tags. The default behavior is currently to prefer `armon/go-metrics` for maximum backwards compatibility. 

Future PRs will:
* Bump the `hashicorp/go-metrics` version to one where the default behavior is to emit metrics using `hashicorp/go-metrics` (Timeline: mid-2025)
* Remove `compat` package usage with direct usage of `hashicorp/go-metrics` (Timeline: end-2025)


TODO:
- [x]  Pull in a tagged version of `hashicorp/go-metrics` once [upstream PR](https://github.com/hashicorp/go-metrics/pull/169) is merged