### PR TITLE
update: use NewTLSWithALPNDisabled to bypass ALPN reinforcement

### DIFF
--- a/discovery/watcher.go
+++ b/discovery/watcher.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+	expcredentials "google.golang.org/grpc/experimental/credentials"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/status"
 )
@@ -119,7 +120,7 @@ func NewWatcher(ctx context.Context, config Config, log hclog.Logger) (*Watcher,
 
 	var cred credentials.TransportCredentials
 	if tls := w.config.TLS; tls != nil {
-		cred = credentials.NewTLS(tls)
+		cred = expcredentials.NewTLSWithALPNDisabled(tls)
 	} else {
 		cred = insecure.NewCredentials()
 	}


### PR DESCRIPTION
- update: use NewTLSWithALPNDisabled to bypass ALPN reinforcement. Consul gRPC server does not enforce ALPN, which breaks the connection.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
